### PR TITLE
feat(user):회원가입 기능 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,9 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+
+	implementation 'at.favre.lib:bcrypt:0.10.2'
+
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/com/example/newsfeed/common/config/PasswordEncoder.java
+++ b/src/main/java/com/example/newsfeed/common/config/PasswordEncoder.java
@@ -1,0 +1,17 @@
+package com.example.newsfeed.common.config;
+
+import at.favre.lib.crypto.bcrypt.BCrypt;
+import org.springframework.stereotype.Component;
+
+@Component
+public class PasswordEncoder {
+
+    public String encode(String rawPassword) {
+        return BCrypt.withDefaults().hashToString(BCrypt.MIN_COST, rawPassword.toCharArray());
+    }
+
+    public boolean matches(String rawPassword, String encodedPassword) {
+        BCrypt.Result result = BCrypt.verifyer().verify(rawPassword.toCharArray(), encodedPassword);
+        return result.verified;
+    }
+}

--- a/src/main/java/com/example/newsfeed/common/exception/ErrorCode.java
+++ b/src/main/java/com/example/newsfeed/common/exception/ErrorCode.java
@@ -13,7 +13,9 @@ public enum ErrorCode {
     DUPLICATE_MEMBER(HttpStatus.BAD_REQUEST,"DUPLICATE_MEMBER","이미 존재하는 회원입니다." ),
     LOGIN_FAILED(HttpStatus.UNAUTHORIZED,"LOGIN_FAILED","아이디 또는 비밀번호가 맞지 않습니다."),
     PAGE_NOT_POSITIVE(HttpStatus.NOT_FOUND,"PAGE_NOT_POSITIVE", "0이하의 페이지 번호 요청"),
-    PAGE_OVER(HttpStatus.NOT_FOUND,"PAGE_OVER","최대 페이지 번호 초과");
+    PAGE_OVER(HttpStatus.NOT_FOUND,"PAGE_OVER","최대 페이지 번호 초과"),
+    PASSWORD_CHECK_MISMATCH(HttpStatus.BAD_REQUEST,"PASSWORD_CHECK_MISMATCH","비밀번호와 비밀번호 확인이 일치하지 않습니다."),
+    INVALID_INTEREST_TAG(HttpStatus.BAD_REQUEST,"INVALID_INTEREST_TAG", "유효하지 않은 관심 태그입니다.");
 
     private final HttpStatus status;
     private final String code;

--- a/src/main/java/com/example/newsfeed/common/exception/ValidationException.java
+++ b/src/main/java/com/example/newsfeed/common/exception/ValidationException.java
@@ -1,0 +1,7 @@
+package com.example.newsfeed.common.exception;
+
+public class ValidationException extends NewsfeedAppException{
+    public ValidationException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/com/example/newsfeed/common/response/MessageResponse.java
+++ b/src/main/java/com/example/newsfeed/common/response/MessageResponse.java
@@ -1,0 +1,18 @@
+package com.example.newsfeed.common.response;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.Getter;
+
+@Getter
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class MessageResponse {
+    String message;
+
+    private MessageResponse(String message) {
+        this.message = message;
+    }
+
+    public static MessageResponse of(String message) {
+        return new MessageResponse(message);
+    }
+}

--- a/src/main/java/com/example/newsfeed/common/validator/EnumValid.java
+++ b/src/main/java/com/example/newsfeed/common/validator/EnumValid.java
@@ -1,0 +1,23 @@
+package com.example.newsfeed.common.validator;
+
+import com.example.newsfeed.user.entity.InterestTag;
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Constraint(
+        validatedBy = EnumValidator.class
+)
+@Target(ElementType.FIELD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface EnumValid {
+
+    Class<?>[] groups() default {};
+    Class<? extends Payload>[] payload() default {};
+    String message() default "Invalid Value This is not permitted";
+    Class<? extends Enum> enummClass();
+}

--- a/src/main/java/com/example/newsfeed/common/validator/EnumValidator.java
+++ b/src/main/java/com/example/newsfeed/common/validator/EnumValidator.java
@@ -1,0 +1,26 @@
+package com.example.newsfeed.common.validator;
+
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+import org.springframework.util.StringUtils;
+
+import java.util.Arrays;
+
+public class EnumValidator implements ConstraintValidator<EnumValid, String> {
+
+    private Enum[] enumValues;
+
+    @Override
+    public void initialize(EnumValid constraintAnnotation) {
+        this.enumValues = constraintAnnotation.enummClass().getEnumConstants();
+    }
+
+    @Override
+    public boolean isValid(String value, ConstraintValidatorContext constraintValidatorContext) {
+        if (!StringUtils.hasText(value)) {
+            return false;
+        }
+
+        return Arrays.stream(enumValues).anyMatch(anEnum -> anEnum.name().equals(value));
+    }
+}

--- a/src/main/java/com/example/newsfeed/user/controller/UserController.java
+++ b/src/main/java/com/example/newsfeed/user/controller/UserController.java
@@ -1,0 +1,31 @@
+package com.example.newsfeed.user.controller;
+
+import com.example.newsfeed.common.response.MessageResponse;
+import com.example.newsfeed.user.dto.SignupRequestDto;
+import com.example.newsfeed.user.service.UserService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/users")
+public class UserController {
+
+    private final UserService userService;
+
+    @PostMapping
+    public ResponseEntity<MessageResponse> signup(@RequestBody @Valid SignupRequestDto requestDto) {
+
+        userService.signup(requestDto);
+        return new ResponseEntity<>(MessageResponse.of("회원가입이 성공하였습니다."), HttpStatus.CREATED);
+    }
+
+
+
+}

--- a/src/main/java/com/example/newsfeed/user/dto/SignupRequestDto.java
+++ b/src/main/java/com/example/newsfeed/user/dto/SignupRequestDto.java
@@ -1,0 +1,35 @@
+package com.example.newsfeed.user.dto;
+
+import com.example.newsfeed.common.validator.EnumValid;
+import com.example.newsfeed.user.entity.InterestTag;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import lombok.Getter;
+
+@Getter
+public class SignupRequestDto {
+
+    @NotBlank(message = "이름은 널일 수 없습니다.")
+    private String name;
+
+    @NotBlank(message = "이메일은 널일 수 없습니다.")
+    @Email
+    private String email;
+
+    @NotBlank(message = "비밀번호는 널일 수 없습니다.")
+    @Pattern(regexp = "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[~!@#$%^&*()+|=])[A-Za-z\\d~!@#$%^&*()+|=]{8,16}$",
+            message = "비밀번호는 영문/숫자/특수문자 최소 1개씩 포함, 8~16자로 설정해주세요. 적어도 하나의 특수 문자 (물결표(~), 느낌표(!), @, #, $, %, ^, &, *, (, ), +, | 등)가 포함되어야 합니다.")
+    private String password;
+
+    @Pattern(regexp = "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[~!@#$%^&*()+|=])[A-Za-z\\d~!@#$%^&*()+|=]{8,16}$",
+            message = "비밀번호 확인은 영문/숫자/특수문자 최소 1개씩 포함, 8~16자로 설정해주세요. 적어도 하나의 특수 문자 (물결표(~), 느낌표(!), @, #, $, %, ^, &, *, (, ), +, | 등)가 포함되어야 합니다.")
+    @NotBlank(message = "비밀번호확인은 널일 수 없습니다.")
+    private String passwordCheck;
+
+    @EnumValid(enummClass = InterestTag.class, message = "유효한 태그를 입력하세요")
+    @NotBlank(message = "태그는 널일 수 없습니다.")
+    private String interestTag;
+
+
+}

--- a/src/main/java/com/example/newsfeed/user/entity/InterestTag.java
+++ b/src/main/java/com/example/newsfeed/user/entity/InterestTag.java
@@ -1,0 +1,22 @@
+package com.example.newsfeed.user.entity;
+
+import com.example.newsfeed.common.exception.ErrorCode;
+import com.example.newsfeed.common.exception.ValidationException;
+
+import java.util.Arrays;
+
+public enum InterestTag {
+    FITNESS,
+    TRAVEL,
+    FOOD,
+    GAMING,
+    ART,
+    FASHION;
+
+    public static InterestTag of(String interestTag) {
+        return Arrays.stream(InterestTag.values())
+                .filter(tag -> tag.name().equals(interestTag))
+                .findFirst()
+                .orElseThrow(() -> new ValidationException(ErrorCode.INVALID_INTEREST_TAG));
+    }
+}

--- a/src/main/java/com/example/newsfeed/user/entity/User.java
+++ b/src/main/java/com/example/newsfeed/user/entity/User.java
@@ -1,0 +1,50 @@
+package com.example.newsfeed.user.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.Table;
+import lombok.Getter;
+
+@Getter
+@Entity
+@Table(name = "users")
+public class User {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    @Column(nullable = false)
+    private String name;
+    @Column(nullable = false, unique = true)
+    private String email;
+    @Column(nullable = false)
+    private String password;
+    @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
+    private InterestTag interestTag;
+    @Enumerated(EnumType.STRING)
+    private UserStatus status;
+
+    protected User() {
+
+    }
+
+    public User(String name, String password, String email, InterestTag interestTag) {
+        this.name = name;
+        this.password = password;
+        this.email = email;
+        this.interestTag = interestTag;
+    }
+
+    @PrePersist
+    protected void prePersist() {
+        this.status = UserStatus.ACTIVE;
+    }
+
+
+}

--- a/src/main/java/com/example/newsfeed/user/entity/UserStatus.java
+++ b/src/main/java/com/example/newsfeed/user/entity/UserStatus.java
@@ -1,0 +1,6 @@
+package com.example.newsfeed.user.entity;
+
+public enum UserStatus {
+    ACTIVE,
+    DEACTIVATED
+}

--- a/src/main/java/com/example/newsfeed/user/exception/DuplicateUserException.java
+++ b/src/main/java/com/example/newsfeed/user/exception/DuplicateUserException.java
@@ -1,0 +1,11 @@
+package com.example.newsfeed.user.exception;
+
+import com.example.newsfeed.common.exception.ErrorCode;
+import com.example.newsfeed.common.exception.NewsfeedAppException;
+
+
+public class DuplicateUserException extends NewsfeedAppException {
+    public DuplicateUserException() {
+        super(ErrorCode.DUPLICATE_MEMBER);
+    }
+}

--- a/src/main/java/com/example/newsfeed/user/repository/UserRepository.java
+++ b/src/main/java/com/example/newsfeed/user/repository/UserRepository.java
@@ -1,0 +1,12 @@
+package com.example.newsfeed.user.repository;
+
+import com.example.newsfeed.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+     boolean existsByEmail(String email);
+
+     Optional<User> findByEmail(String email);
+}

--- a/src/main/java/com/example/newsfeed/user/service/UserService.java
+++ b/src/main/java/com/example/newsfeed/user/service/UserService.java
@@ -1,0 +1,51 @@
+package com.example.newsfeed.user.service;
+
+import com.example.newsfeed.common.config.PasswordEncoder;
+import com.example.newsfeed.common.exception.ValidationException;
+import com.example.newsfeed.user.dto.SignupRequestDto;
+import com.example.newsfeed.user.entity.InterestTag;
+import com.example.newsfeed.user.entity.User;
+import com.example.newsfeed.user.exception.DuplicateUserException;
+import com.example.newsfeed.user.exception.UserNotFoundException;
+import com.example.newsfeed.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import static com.example.newsfeed.common.exception.ErrorCode.PASSWORD_CHECK_MISMATCH;
+
+@Service
+@RequiredArgsConstructor
+public class UserService {
+
+    private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
+
+
+    @Transactional
+    public void signup(SignupRequestDto requestDto) {
+        if (!isMatchingPassword(requestDto.getPassword(), requestDto.getPasswordCheck())) {
+            throw new ValidationException(PASSWORD_CHECK_MISMATCH);
+        }
+
+        InterestTag interestTag = InterestTag.of(requestDto.getInterestTag());
+
+        if (userRepository.existsByEmail(requestDto.getEmail())){
+            throw new DuplicateUserException();
+        }
+
+        String encodedPassword = passwordEncoder.encode(requestDto.getPassword());
+
+        User user = new User(requestDto.getName(),encodedPassword, requestDto.getEmail(),interestTag);
+        userRepository.save(user);
+    }
+
+    @Transactional(readOnly = true)
+    public User getUserByEmail(String email) {
+        return userRepository.findByEmail(email).orElseThrow(()-> new UserNotFoundException());
+    }
+
+    private boolean isMatchingPassword(String password, String passwordCheck) {
+        return password != null && password.equals(passwordCheck);
+    }
+}


### PR DESCRIPTION
- 회원 가입 API ('POST /api/v1/users') 구현
- (common/config) 비밀번호 암호화를 위한 'PasswordEncoder' 적용
- (common/response) 'MessageResponse' 클래스 추가 (String 응답 메시지 통일)
- (common/validator) 'EnumValid' 어노테이션 추가 (ENUM 값 검증)
- (common/exception) 요청값 검증용 'ValidationException' 추가